### PR TITLE
Mitigates audio stutter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ install: pocketchip-one pocketchip-one.service
 	systemctl enable pocketchip-one.service
 	systemctl reload-or-restart pocketchip-one.service
 
+	# Copy and enable our polite NAND service.
+	cp -f ./ubihealthd.service /etc/systemd/system/
+	systemctl reload-or-restart ubihealthd.service
+
 uninstall:
 	# Stop and disable our service.
 	systemctl disable pocketchip-one.service

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Since nobody needs the real voltage and because fuel gauge is so much better I'v
 the actual voltage and use the fuel gauge to calculate "virtual" voltage which after mapping by the home screen will
 become a fuel gauge effectively improving the battery indicator.
 
+`ubihealthd` causes additional stutter on 4.4, this appears to be due to excessive logging.
+The modified ubihealthd.service lowers the logging level and increases niceness of the process,
+mitigating the random audio stutter further.
+
 ## Installation
 
 (If you have the older version of the script, then first uninstall it using the original sources.)
@@ -59,8 +63,6 @@ If you want to undo the changes:
 
  - `pocket-home` appears to be constantly consuming up to 1-4% of CPU, must be polling something fairly hard, would be great to patch it. 
    I've personallly moved to JWM, see my config [here](https://github.com/aleh/pocketchip-jwmrc).
-
- - `ubihealthd` seems to be causing additional stutter  on 4.4;
 
  - we should patch `rsyslogd.conf` with our Makefile as described [here](https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=134971#p898539);
 

--- a/ubihealthd.service
+++ b/ubihealthd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Politer, less verbose NAND health watchdog service
+ConditionFileIsExecutable=/usr/sbin/ubihealthd
+After=systemd-journald.socket
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/ubihealthd -d /dev/ubi0 -f /var/cache/ubihealthd.v1.stats -r 86400 -x 100 -s 864000 -v3
+PIDFile=/run/ubihealthd.pid
+StandardOutput=journal
+Restart=on-failure
+Nice=19
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
By making ubihealthd more polite and less verbose.
The -v3 flag reduces the logging level
Nice=19 makes ubihealthd have lower priority.